### PR TITLE
feat: Add RobustVideoMatting for temporal portrait matting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and the face states stay `None` until you pass the predictor that fills them.
 | Face Tracking | BYTETracker, persistent IDs across video frames |
 | Facial Landmarks | 2d106det (106), PIPNet (98 / 68), Face Mesh (468 / 478, 3D) |
 | Face Parsing | BiSeNet (19 classes), XSeg masking |
-| Portrait Matting | MODNet, trimap-free |
+| Portrait Matting | MODNet, RobustVideoMatting (temporal video) |
 | Gaze Estimation | MobileGaze (ResNet-18 / 34 / 50, MobileNetV2) |
 | Head Pose | 6D rotation representation, pitch / yaw / roll |
 | Demographics | AgeGender, FairFace (age group, sex, race) |

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -124,7 +124,7 @@ uniface/
 ├── landmark/       # Dense landmarks (Landmark106 = 106 pts, PIPNet = 98 / 68 pts, FaceMesh = 468 / 478 pts)
 ├── attribute/      # Age, gender, emotion, race, face states
 ├── parsing/        # Face semantic segmentation
-├── matting/        # Portrait matting (MODNet)
+├── matting/        # Portrait matting (MODNet, RobustVideoMatting)
 ├── gaze/           # Gaze estimation
 ├── headpose/       # Head pose estimation
 ├── spoofing/       # Anti-spoofing (MiniFASNet)

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ BiSeNet semantic segmentation with 19 facial component classes, plus XSeg face m
 
 <div class="feature-card" markdown>
 ### :material-image-off: Portrait Matting
-Trimap-free alpha matte with MODNet for background removal and compositing.
+Trimap-free alpha matte with MODNet and RobustVideoMatting (temporal, flicker-free video) for background removal and compositing.
 <a class="feature-card-link" href="modules/matting/" aria-label="Portrait Matting"></a>
 </div>
 

--- a/docs/license-attribution.md
+++ b/docs/license-attribution.md
@@ -23,6 +23,7 @@ UniFace is released under the [MIT License](https://opensource.org/licenses/MIT)
 | BiSeNet | [yakhyo/face-parsing](https://github.com/yakhyo/face-parsing) | MIT |
 | MobileGaze | [yakhyo/gaze-estimation](https://github.com/yakhyo/gaze-estimation) | MIT |
 | MODNet | [yakhyo/modnet](https://github.com/yakhyo/modnet) | Apache-2.0 |
+| RobustVideoMatting | [PeterL1n/RobustVideoMatting](https://github.com/PeterL1n/RobustVideoMatting) | GPL-3.0 |
 | MiniFASNet | [yakhyo/face-anti-spoofing](https://github.com/yakhyo/face-anti-spoofing) | Apache-2.0 |
 | FairFace | [yakhyo/fairface-onnx](https://github.com/yakhyo/fairface-onnx) | CC BY 4.0 |
 | FaceAttribNet | [yakhyo/face-attribute](https://github.com/yakhyo/face-attribute) — architecture & weights © Qualcomm Technologies, Inc. ([qualcomm/ai-hub-models](https://github.com/qualcomm/ai-hub-models)) | BSD-3-Clause |

--- a/docs/models.md
+++ b/docs/models.md
@@ -521,6 +521,35 @@ MODNet (Real-Time Trimap-Free Portrait Matting) produces soft alpha mattes from 
 
 ---
 
+### RobustVideoMatting
+
+RobustVideoMatting (RVM) produces alpha mattes from full images **and videos**. It is a recurrent network that carries temporal memory across frames, so video mattes stay stable on hair and other high-frequency edges where per-frame models flicker.
+
+| Model Name | Size | Use Case |
+| ---------- | ---- | -------- |
+| `MOBILENETV3` :material-check-circle: | 15 MB | Real-time / default |
+| `RESNET50` | 107 MB | Higher-capacity backbone |
+
+!!! info "Model Details"
+    **Paper**: [Robust High-Resolution Video Matting with Temporal Guidance](https://arxiv.org/abs/2108.11515) (WACV 2022)
+
+    **Source**: [PeterL1n/RobustVideoMatting](https://github.com/PeterL1n/RobustVideoMatting) — official ONNX weights
+
+    **Output**: Alpha matte `(H, W)` in `[0, 1]` (per frame)
+
+    **License**: [GPL-3.0](license-attribution.md)
+
+**Applications:**
+
+- Flicker-free video background removal
+- Video conferencing virtual backgrounds
+- Green screen compositing with stable hair edges
+
+!!! note "Video Usage"
+    Use `predict_frame()` / `predict_frames()` in a video loop so RVM can recycle its recurrent state; call `reset()` before a new sequence or after scene cuts. See [modules/matting](modules/matting.md).
+
+---
+
 ## Anti-Spoofing Models
 
 ### MiniFASNet Family
@@ -593,6 +622,7 @@ See [Model Cache & Offline Use](concepts/model-cache-offline.md) for full detail
 - **Face Parsing Training**: [yakhyo/face-parsing](https://github.com/yakhyo/face-parsing) - BiSeNet training code and pretrained weights
 - **Face Segmentation**: [yakhyo/face-segmentation](https://github.com/yakhyo/face-segmentation) - XSeg ONNX Inference
 - **Portrait Matting**: [yakhyo/modnet](https://github.com/yakhyo/modnet) - MODNet ported weights and inference (from [ZHKKKe/MODNet](https://github.com/ZHKKKe/MODNet))
+- **RobustVideoMatting**: [PeterL1n/RobustVideoMatting](https://github.com/PeterL1n/RobustVideoMatting) - Temporal-guidance video matting (official ONNX weights)
 - **Face Anti-Spoofing**: [yakhyo/face-anti-spoofing](https://github.com/yakhyo/face-anti-spoofing) - MiniFASNet ONNX inference (weights from [minivision-ai/Silent-Face-Anti-Spoofing](https://github.com/minivision-ai/Silent-Face-Anti-Spoofing))
 - **Face Image Quality Assessment**: [yakhyo/face-image-quality-assessment](https://github.com/yakhyo/face-image-quality-assessment) - eDifFIQA PyTorch inference, ONNX export and inference
 - **FairFace**: [yakhyo/fairface-onnx](https://github.com/yakhyo/fairface-onnx) - FairFace ONNX inference for race, gender, age prediction
@@ -609,5 +639,6 @@ See [Model Cache & Offline Use](concepts/model-cache-offline.md) for full detail
 - **ArcFace**: [Additive Angular Margin Loss for Deep Face Recognition](https://arxiv.org/abs/1801.07698)
 - **SphereFace**: [Deep Hypersphere Embedding for Face Recognition](https://arxiv.org/abs/1704.08063)
 - **MODNet**: [Real-Time Trimap-Free Portrait Matting via Objective Decomposition](https://arxiv.org/abs/2011.11961)
+- **RobustVideoMatting**: [Robust High-Resolution Video Matting with Temporal Guidance](https://arxiv.org/abs/2108.11515)
 - **BiSeNet**: [Bilateral Segmentation Network for Real-time Semantic Segmentation](https://arxiv.org/abs/1808.00897)
 - **PIPNet**: [Towards Efficient Facial Landmark Detection in the Wild](https://arxiv.org/abs/2003.03771)

--- a/docs/modules/matting.md
+++ b/docs/modules/matting.md
@@ -15,6 +15,8 @@ Portrait matting produces a soft alpha matte separating the foreground (person) 
 |-------|---------|------|----------|
 | **MODNet Photographic** :material-check-circle: | PHOTOGRAPHIC | 25 MB | High-quality portrait photos |
 | MODNet Webcam | WEBCAM | 25 MB | Real-time webcam feeds |
+| **RobustVideoMatting** :material-check-circle: | MOBILENETV3 | 15 MB | Temporal-stable matting for video |
+| RobustVideoMatting | RESNET50 | 107 MB | Video matting with a higher-capacity backbone |
 
 ---
 
@@ -96,6 +98,64 @@ cv2.imwrite("green_screen.jpg", green)
 MODNet is trimap-free, so a background that competes with the subject in sharpness and contrast
 is where the alpha edge softens. Compositing onto a blurred or plain background hides most of it;
 if you need a clean cut, shoot against a plain wall.
+
+---
+
+## Video Matting with RobustVideoMatting
+
+For **video**, per-frame matting flickers on hair and other high-frequency edges. RobustVideoMatting
+(RVM) is a *recurrent* network: it carries temporal memory across frames, so the alpha stays stable
+from frame to frame.
+
+```python
+import cv2
+from uniface.matting import RobustVideoMatting
+
+matting = RobustVideoMatting()          # MobileNetV3 (fast). RESNET50 is the higher-capacity variant.
+
+cap = cv2.VideoCapture("video.mp4")
+matting.reset()                          # Start a new sequence (also call after scene cuts)
+
+while True:
+    ret, frame = cap.read()
+    if not ret:
+        break
+
+    matte = matting.predict_frame(frame)  # (H, W) float32 in [0, 1], reusing temporal memory
+    # ... composite `frame` and `matte` as shown above ...
+```
+
+For a list of frames at once (e.g. a preloaded clip), `predict_frames` returns the stacked mattes:
+
+```python
+mattes = matting.predict_frames(frames)  # (T, H, W) float32
+```
+
+### API notes
+
+- `predict(image)` processes a single image **without** temporal memory — use it for unrelated stills.
+  It never carries state between calls.
+- `predict_frame(frame)` / `predict_frames(frames)` reuse memory across frames. Memory is kept
+  between calls for chunked processing, and is reset automatically if the frame size changes.
+  Call `reset()` before starting an unrelated video.
+- `downsample_ratio` trades speed against detail (default `None` = auto, largest side mapped to
+  ~512 px). Lower it for lower resolutions, raise it when the full body is in shot.
+- The RVM model weights are [GPL-3.0 licensed](../license-attribution.md); check before shipping
+  commercially.
+
+```python
+from uniface.constants import RobustVideoMattingWeights
+from uniface.matting import RobustVideoMatting
+
+matting = RobustVideoMatting(model_name=RobustVideoMattingWeights.RESNET50,
+                             downsample_ratio=0.25)
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `model_name` | `MOBILENETV3` | Model variant to load |
+| `downsample_ratio` | `None` | Internal working resolution fraction; `None` = auto |
+| `providers` | `None` | ONNX Runtime execution providers |
 
 ### Custom Background
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -559,7 +559,7 @@ For detailed model comparisons and benchmarks, see the [Model Zoo](models.md).
 | Gaze | `MobileGaze` (ResNet18/34/50, MobileNetV2, MobileOneS0) |
 | Head Pose | `HeadPose` (ResNet18/34/50, MobileNetV2/V3) |
 | Parsing | `BiSeNet` (ResNet18/34), `XSeg` |
-| Matting | `MODNet` |
+| Matting | `MODNet`, `RobustVideoMatting` (temporal video) |
 | Attributes | `AgeGender`, `FairFace`, `Emotion`, `FaceAttribNet` (face states) |
 | Anti-Spoofing | `MiniFASNet` (V1SE, V2) |
 | Quality | `EDifFIQA` (T, S, M, L) |

--- a/tests/test_rvm.py
+++ b/tests/test_rvm.py
@@ -1,0 +1,161 @@
+# Copyright 2025-2026 Yakhyokhuja Valikhujaev
+# Author: Yakhyokhuja Valikhujaev
+# GitHub: https://github.com/yakhyo
+
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from uniface.constants import RobustVideoMattingWeights
+from uniface.matting import RobustVideoMatting
+
+
+def test_rvm_initialization():
+    """Test RobustVideoMatting initialization with default weights."""
+    matting = RobustVideoMatting()
+    assert matting is not None
+    assert matting.downsample_ratio is None
+
+
+def test_rvm_with_resnet50_weights_enum():
+    """Test the resnet50 enum value maps to the expected model string."""
+    assert RobustVideoMattingWeights.RESNET50.value == 'rvm_resnet50'
+
+
+def test_rvm_invalid_downsample_ratio():
+    """Test that out-of-range downsample ratios are rejected."""
+    with pytest.raises(ValueError):
+        RobustVideoMatting(downsample_ratio=0)
+    with pytest.raises(ValueError):
+        RobustVideoMatting(downsample_ratio=1.5)
+
+
+def test_rvm_preprocess():
+    """Test preprocessing produces a [0, 1] RGB tensor at the original size."""
+    matting = RobustVideoMatting()
+
+    image = np.zeros((128, 160, 3), dtype=np.uint8)
+    image[:, :] = (0, 128, 255)  # BGR -> expected RGB (255, 128, 0)
+    tensor, orig_h, orig_w = matting.preprocess(image)
+
+    assert tensor.dtype == np.float32
+    assert tensor.ndim == 4
+    assert tensor.shape[0] == 1
+    assert tensor.shape[1] == 3
+    assert tensor.shape[2] == 128
+    assert tensor.shape[3] == 160
+    assert tensor.min() >= 0.0
+    assert tensor.max() <= 1.0
+    assert orig_h == 128
+    assert orig_w == 160
+
+    # BGR -> RGB channel swap and 0..1 normalization
+    assert tensor[0, 0, 0, 0] == pytest.approx(1.0)
+    assert tensor[0, 1, 0, 0] == pytest.approx(128 / 255)
+    assert tensor[0, 2, 0, 0] == pytest.approx(0.0)
+
+
+def test_rvm_postprocess():
+    """Test postprocessing squeezes and resizes the alpha output."""
+    matting = RobustVideoMatting()
+
+    dummy_output = np.random.rand(1, 1, 64, 80).astype(np.float32)
+    matte = matting.postprocess(dummy_output, original_size=(80, 64))
+
+    assert matte.shape == (64, 80)
+    assert matte.dtype == np.float32
+
+    matte_resized = matting.postprocess(dummy_output, original_size=(160, 128))
+    assert matte_resized.shape == (128, 160)
+
+
+def test_rvm_auto_downsample_ratio():
+    """Test automatic downsample ratio keeps the largest side near 512 px."""
+    matting = RobustVideoMatting()
+
+    assert matting._resolve_ratio(1920, 1080) == pytest.approx(512 / 1920)
+    assert matting._resolve_ratio(512, 512) == 1.0
+    assert matting._resolve_ratio(100, 200) == 1.0
+
+
+def test_rvm_fixed_downsample_ratio():
+    """Test a user-provided downsample ratio is used as-is."""
+    matting = RobustVideoMatting(downsample_ratio=0.25)
+
+    assert matting._resolve_ratio(1920, 1080) == 0.25
+    assert matting._resolve_ratio(100, 200) == 0.25
+
+
+def test_rvm_reset():
+    """Test that reset drops the recurrent state."""
+    matting = RobustVideoMatting()
+
+    image = np.random.randint(0, 255, (128, 128, 3), dtype=np.uint8)
+    matting.predict_frame(image)
+    assert matting._states is not None
+
+    matting.reset()
+    assert matting._states is None
+    assert matting._state_key is None
+
+
+def test_rvm_predict():
+    """Test stateless single-image prediction."""
+    matting = RobustVideoMatting()
+
+    image = np.random.randint(0, 255, (128, 128, 3), dtype=np.uint8)
+    matte = matting.predict(image)
+
+    assert matte.shape == (128, 128)
+    assert matte.dtype == np.float32
+    assert matte.min() >= 0.0
+    assert matte.max() <= 1.0
+
+
+def test_rvm_predict_is_stateless():
+    """Test that two identical images give identical results (no hidden memory)."""
+    matting = RobustVideoMatting()
+
+    image = np.random.randint(0, 255, (128, 128, 3), dtype=np.uint8)
+    matte1 = matting.predict(image)
+    matte2 = matting.predict(image)
+
+    assert np.allclose(matte1, matte2)
+
+
+def test_rvm_predict_frame_sequence():
+    """Test stateful frame-by-frame prediction for video."""
+    matting = RobustVideoMatting()
+    matting.reset()
+
+    size = (96, 128)
+    frames = [np.random.randint(0, 255, (*size, 3), dtype=np.uint8) for _ in range(3)]
+    mattes = [matting.predict_frame(frame) for frame in frames]
+
+    assert all(matte.shape == size for matte in mattes)
+    assert matting._states is not None
+
+
+def test_rvm_predict_frames():
+    """Test batch frame prediction returns a (T, H, W) stack."""
+    matting = RobustVideoMatting()
+    matting.reset()
+
+    frames = [np.random.randint(0, 255, (96, 128, 3), dtype=np.uint8) for _ in range(3)]
+    mattes = matting.predict_frames(frames)
+
+    assert mattes.shape == (3, 96, 128)
+    assert mattes.dtype == np.float32
+
+
+def test_rvm_callable():
+    """Test that RobustVideoMatting is callable via __call__."""
+    matting = RobustVideoMatting()
+    image = np.random.randint(0, 255, (96, 96, 3), dtype=np.uint8)
+
+    matte = matting(image)
+
+    assert matte.shape == (96, 96)
+    assert matte.dtype == np.float32

--- a/uniface/__init__.py
+++ b/uniface/__init__.py
@@ -38,7 +38,7 @@ from .detection import SCRFD, BlazeFace, CenterFace, RetinaFace, YOLOv5Face, YOL
 from .gaze import MobileGaze
 from .headpose import HeadPose
 from .landmark import FaceMesh, Landmark106, PIPNet
-from .matting import MODNet
+from .matting import MODNet, RobustVideoMatting
 from .parsing import BiSeNet, XSeg
 from .privacy import BlurFace
 from .quality import EDifFIQA
@@ -95,6 +95,7 @@ __all__ = [
     'HeadPoseResult',
     # Matting models
     'MODNet',
+    'RobustVideoMatting',
     # Parsing models
     'BiSeNet',
     'XSeg',

--- a/uniface/constants.py
+++ b/uniface/constants.py
@@ -298,6 +298,20 @@ class MODNetWeights(str, Enum):
     WEBCAM       = "modnet_webcam"
 
 
+class RobustVideoMattingWeights(str, Enum):
+    """Robust Video Matting (RVM): temporal-guidance portrait matting for video.
+
+    RVM is a recurrent network: alpha predictions carry memory across frames,
+    which keeps mattes stable on hair and other high-frequency edges where
+    per-frame models flicker.
+
+    Model weights are GPL-3.0 licensed; see the license-attribution docs page.
+    https://github.com/PeterL1n/RobustVideoMatting
+    """
+    MOBILENETV3 = "rvm_mobilenetv3"
+    RESNET50    = "rvm_resnet50"
+
+
 class MiniFASNetWeights(str, Enum):
     """MiniFASNet: Lightweight Face Anti-Spoofing models.
 
@@ -612,6 +626,16 @@ MODEL_REGISTRY: dict[Enum, ModelInfo] = {
     MODNetWeights.WEBCAM: ModelInfo(
         url='https://github.com/yakhyo/modnet/releases/download/weights/modnet_webcam.onnx',
         sha256='de03cc16f3c91f25b7c2f0b42ea1a8d34f40a752234f3887572655e744e55306'
+    ),
+
+    # RobustVideoMatting (RVM) - GPL-3.0 weights, see docs/license-attribution.md
+    RobustVideoMattingWeights.MOBILENETV3: ModelInfo(
+        url='https://github.com/PeterL1n/RobustVideoMatting/releases/download/v1.0.0/rvm_mobilenetv3_fp32.onnx',
+        sha256='88d4531297118f595bf2fd60f6f566aec2e559393802d1f436c380f0cbbd2828'
+    ),
+    RobustVideoMattingWeights.RESNET50: ModelInfo(
+        url='https://github.com/PeterL1n/RobustVideoMatting/releases/download/v1.0.0/rvm_resnet50_fp32.onnx',
+        sha256='25db300fcb6ee27f941a1b52c97856e8d1f13c7f35817f81a612f89af0e8a85c'
     ),
 
     # eDifFIQA (Face Image Quality Assessment)

--- a/uniface/matting/__init__.py
+++ b/uniface/matting/__init__.py
@@ -6,5 +6,6 @@ from __future__ import annotations
 
 from .base import BaseMatting
 from .modnet import MODNet
+from .rvm import RobustVideoMatting
 
-__all__ = ['BaseMatting', 'MODNet']
+__all__ = ['BaseMatting', 'MODNet', 'RobustVideoMatting']

--- a/uniface/matting/rvm.py
+++ b/uniface/matting/rvm.py
@@ -1,0 +1,306 @@
+# Copyright 2025-2026 Yakhyokhuja Valikhujaev
+# Author: Yakhyokhuja Valikhujaev
+# GitHub: https://github.com/yakhyo
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import cv2
+import numpy as np
+
+from uniface.constants import RobustVideoMattingWeights
+from uniface.log import Logger
+from uniface.model_store import verify_model_weights
+from uniface.onnx_utils import create_onnx_session
+
+from .base import BaseMatting
+
+__all__ = ['RobustVideoMatting']
+
+NUM_RECURRENT_STATES = 4
+MAX_AUTO_SIDE = 512
+
+
+class RobustVideoMatting(BaseMatting):
+    """Robust Video Matting (RVM) with ONNX Runtime.
+
+    RVM is a recurrent portrait-matting network. Unlike per-frame models such as
+    :class:`MODNet`, it carries hidden state across consecutive frames, so the
+    alpha matte stays temporally stable on hair and other high-frequency edges
+    that make frame-by-frame predictions flicker.
+
+    Two pretrained variants are available:
+
+    - `MOBILENETV3`: fast, recommended for most use cases.
+    - `RESNET50`: higher capacity with a modest accuracy gain.
+
+    .. note::
+        Weights are distributed under the GPL-3.0 license
+        (https://github.com/PeterL1n/RobustVideoMatting); see
+        ``docs/license-attribution.md`` before commercial use.
+
+    Raises:
+        ValueError: If the model weights are invalid or not found.
+        RuntimeError: If the ONNX model fails to load or initialize.
+
+    Reference:
+        Lin et al., "Robust High-Resolution Video Matting with Temporal
+        Guidance", WACV 2022.
+        https://github.com/PeterL1n/RobustVideoMatting
+
+    Args:
+        model_name: The enum specifying the RVM variant to load.
+            Defaults to `RobustVideoMattingWeights.MOBILENETV3`.
+        downsample_ratio: Internal working resolution as a fraction of the
+            input size, in ``(0, 1]``. Lower values are faster but coarser.
+            If `None` (default), it is picked automatically so the largest
+            input side maps to about 512 px, matching the upstream guidance.
+        providers: ONNX Runtime execution providers. If `None`, auto-detects
+            the best available provider.
+
+    Attributes:
+        downsample_ratio (float | None): Downsample ratio used during inference.
+
+    Example:
+        >>> from uniface.matting import RobustVideoMatting
+        >>>
+        >>> # Single independent image (no temporal memory is used)
+        >>> matting = RobustVideoMatting()
+        >>> matte = matting.predict(image)  # (H, W) float32 in [0, 1]
+        >>>
+        >>> # Video: carry memory across frames for a stable matte
+        >>> matting.reset()
+        >>> for frame in frames:
+        ...     matte = matting.predict_frame(frame)
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: RobustVideoMattingWeights = RobustVideoMattingWeights.MOBILENETV3,
+        downsample_ratio: float | None = None,
+        providers: list[str] | None = None,
+    ) -> None:
+        if downsample_ratio is not None and not 0.0 < downsample_ratio <= 1.0:
+            raise ValueError('downsample_ratio must be in (0, 1] or None for auto.')
+
+        Logger.info(f'Initializing RobustVideoMatting with model={model_name}')
+
+        self.downsample_ratio = downsample_ratio
+        self.providers = providers
+
+        self.model_path = verify_model_weights(model_name)
+        self._initialize_model()
+
+        # Recurrent state carried between predict_frame calls. None means "no
+        # memory yet", which the model initializes internally from broadcastable
+        # zero states on the next call.
+        self._states: list[np.ndarray] | None = None
+        self._state_key: tuple[int, int, float] | None = None
+
+    def _initialize_model(self) -> None:
+        """Initialize the ONNX model from the stored model path.
+
+        The RVM ONNX graph has one image input, one downsample-ratio input,
+        four recurrent-state inputs, and the matching outputs. Nodes are
+        discovered from shapes rather than hard-coded names so the class keeps
+        working if the graph is re-exported with different tensor names.
+
+        Raises:
+            RuntimeError: If the model fails to load or initialize.
+        """
+        try:
+            self.session = create_onnx_session(self.model_path, providers=self.providers)
+
+            inputs = self.session.get_inputs()
+            outputs = self.session.get_outputs()
+
+            self.src_input = _channel_input(inputs, 3)
+            self.ratio_input = next(i for i in inputs if len(i.shape) == 1)
+            self.state_inputs = [i for i in inputs if i is not self.src_input and i is not self.ratio_input]
+
+            self.fgr_output = _channel_output(outputs, 3)
+            self.pha_output = _channel_output(outputs, 1)
+            self.state_outputs = [o for o in outputs if o is not self.fgr_output and o is not self.pha_output]
+
+            if len(self.state_inputs) != NUM_RECURRENT_STATES or len(self.state_outputs) != NUM_RECURRENT_STATES:
+                raise RuntimeError(
+                    f'Expected {NUM_RECURRENT_STATES} recurrent states, '
+                    f'got {len(self.state_inputs)} inputs / {len(self.state_outputs)} outputs.'
+                )
+
+            Logger.info('RobustVideoMatting initialized')
+
+        except Exception as e:
+            Logger.error(f"Failed to load RobustVideoMatting model from '{self.model_path}'", exc_info=True)
+            raise RuntimeError(f'Failed to initialize RobustVideoMatting model: {e}') from e
+
+    def reset(self) -> None:
+        """Drop the recurrent memory.
+
+        Call this at the start of a new video or after a hard scene cut so
+        predictions do not inherit state from the previous sequence.
+        """
+        self._states = None
+        self._state_key = None
+        Logger.debug('RobustVideoMatting recurrent state reset')
+
+    def preprocess(self, image: np.ndarray) -> tuple[np.ndarray, int, int]:
+        """Preprocess a BGR image for RVM inference.
+
+        RVM expects RGB input normalized to ``[0, 1]`` at the original spatial
+        resolution; the model downsamples internally per `downsample_ratio`.
+        No letterboxing or padding is applied.
+
+        Args:
+            image: Input image in BGR format with shape `(H, W, 3)`.
+
+        Returns:
+            A tuple of `(tensor, orig_h, orig_w)` where *tensor* has shape
+            `(1, 3, H, W)` in float32.
+        """
+        orig_h, orig_w = image.shape[:2]
+        rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        x = rgb.astype(np.float32) / 255.0
+        x = np.transpose(x, (2, 0, 1))
+        return np.expand_dims(x, axis=0), orig_h, orig_w
+
+    def postprocess(self, outputs: np.ndarray, original_size: tuple[int, int]) -> np.ndarray:
+        """Postprocess raw model output into an alpha matte.
+
+        RVM emits the alpha at the source resolution already, so this only
+        squeezes the batch/channel axes and, as a safeguard, resizes to the
+        original size.
+
+        Args:
+            outputs: Raw ONNX alpha output with shape `(1, 1, H, W)`.
+            original_size: Target size as `(width, height)`.
+
+        Returns:
+            Alpha matte with shape `(H, W)`, float32 in `[0, 1]`.
+        """
+        matte = outputs[0, 0]
+        matte = cv2.resize(matte, original_size, interpolation=cv2.INTER_AREA)
+        return matte
+
+    def predict(self, image: np.ndarray) -> np.ndarray:
+        """Run portrait matting on a single image without temporal memory.
+
+        Predictions for unrelated images should stay independent, so this call
+        always starts from a fresh recurrent state and does not persist it.
+        For video use :meth:`reset` plus :meth:`predict_frame`, or
+        :meth:`predict_frames`.
+
+        Args:
+            image: Input image in BGR format with shape `(H, W, 3)`.
+
+        Returns:
+            Alpha matte with shape `(H, W)`, float32 in `[0, 1]`.
+        """
+        tensor, orig_h, orig_w = self.preprocess(image)
+        ratio = self._resolve_ratio(orig_h, orig_w)
+        _, pha, _ = self._run(tensor, ratio, states=None)
+        return self.postprocess(pha, (orig_w, orig_h))
+
+    def predict_frame(self, image: np.ndarray) -> np.ndarray:
+        """Run matting on the next frame of a video, reusing temporal memory.
+
+        Call :meth:`reset` before the first frame (or after a scene cut), then
+        feed frames in order. Memory is kept across calls so the matte stays
+        stable from frame to frame.
+
+        Args:
+            image: Input frame in BGR format with shape `(H, W, 3)`.
+
+        Returns:
+            Alpha matte with shape `(H, W)`, float32 in `[0, 1]`.
+        """
+        tensor, orig_h, orig_w = self.preprocess(image)
+        ratio = self._resolve_ratio(orig_h, orig_w)
+        key = (orig_h, orig_w, ratio)
+        if self._states is not None and key != self._state_key:
+            Logger.debug('RobustVideoMatting frame geometry changed; resetting recurrent state')
+            self.reset()
+        _, pha, states = self._run(tensor, ratio, states=self._states)
+        self._states = states
+        self._state_key = key
+        return self.postprocess(pha, (orig_w, orig_h))
+
+    def predict_frames(self, frames: Sequence[np.ndarray]) -> np.ndarray:
+        """Run matting on a sequence of frames with shared temporal memory.
+
+        Convenience wrapper around :meth:`predict_frame`. Geometry changes
+        between frames reset the memory automatically. Recurrent state is
+        retained across calls for chunked processing; call :meth:`reset` before
+        starting an unrelated sequence.
+
+        Args:
+            frames: Iterable of BGR frames, each with shape `(H, W, 3)`.
+
+        Returns:
+            Alpha mattes stacked along a new leading axis with shape `(T, H, W)`,
+            float32 in `[0, 1]`.
+        """
+        mattes = [self.predict_frame(frame) for frame in frames]
+        return np.stack(mattes, axis=0)
+
+    def _resolve_ratio(self, h: int, w: int) -> float:
+        """Return the downsample ratio for a frame of the given size."""
+        if self.downsample_ratio is not None:
+            return self.downsample_ratio
+        # Upstream auto rule: map the largest side down to ~512 px.
+        return min(MAX_AUTO_SIDE / max(h, w), 1.0)
+
+    def _run(
+        self,
+        src: np.ndarray,
+        ratio: float,
+        states: list[np.ndarray] | None,
+    ) -> tuple[np.ndarray, np.ndarray, list[np.ndarray] | None]:
+        """Run one forward pass, optionally recycling recurrent states.
+
+        Args:
+            src: Preprocessed source tensor with shape `(1, 3, H, W)`.
+            ratio: Downsample ratio for this pass.
+            states: Previous recurrent states, or `None` for a fresh start.
+
+        Returns:
+            Tuple of `(fgr, pha, new_states)` where *new_states* are the
+            recurrent outputs of this pass and can be fed back on the next frame.
+        """
+        if states is None:
+            # The exported graph broadcasts 1x1x1x1 zeros to the internal state
+            # geometry, so a shape-generic zero init works for any resolution.
+            zeros = [np.zeros((1, 1, 1, 1), dtype=np.float32) for _ in range(NUM_RECURRENT_STATES)]
+            states = zeros
+
+        feeds = dict(zip([i.name for i in self.state_inputs], states, strict=True))
+        feeds[self.src_input.name] = src
+        feeds[self.ratio_input.name] = np.asarray([ratio], dtype=np.float32)
+
+        outputs = self.session.run(
+            [self.fgr_output.name, self.pha_output.name] + [o.name for o in self.state_outputs],
+            feeds,
+        )
+        fgr, pha = outputs[0], outputs[1]
+        new_states = list(outputs[2:])
+        return fgr, pha, new_states
+
+
+def _channel_input(inputs, channels: int):
+    """Return the graph input whose spatial channels match `channels`."""
+    for i in inputs:
+        shape = i.shape
+        if len(shape) == 4 and shape[1] == channels:
+            return i
+    raise RuntimeError(f'No input tensor with {channels} channels found in model.')
+
+
+def _channel_output(outputs, channels: int):
+    """Return the graph output whose spatial channels match `channels`."""
+    for o in outputs:
+        shape = o.shape
+        if len(shape) == 4 and shape[1] == channels:
+            return o
+    raise RuntimeError(f'No output tensor with {channels} channels found in model.')


### PR DESCRIPTION
Closes #123

## Summary

Adds **RobustVideoMatting (RVM)** as a portrait-matting backend. Unlike per-frame models such as MODNet, RVM is a recurrent network that carries temporal memory across video frames, so alpha mattes stay stable on hair and other high-frequency edges that make frame-by-frame predictions flicker.

## Changes

- **`uniface/matting/rvm.py`** — new `RobustVideoMatting(BaseMatting)`:
  - Graph I/O discovered from tensor shapes, so it keeps working if the ONNX graph is re-exported with different names (src / 4 recurrent states in-out / downsample_ratio).
  - `predict(image)` — stateless, for independent stills (same contract as `MODNet`).
  - `reset()` + `predict_frame(frame)` / `predict_frames(frames)` — stateful video matting; recurrent state recycled across frames and auto-reset when frame geometry changes.
  - `downsample_ratio` param defaulting to upstream auto (`min(512/max(h,w), 1)`); rejected outside `(0, 1]`.
- **`uniface/constants.py`** — `RobustVideoMattingWeights` enum (`MOBILENETV3`, `RESNET50`) + SHA-256-verified `MODEL_REGISTRY` entries pointing at the official RVM v1.0.0 fp32 ONNX weights.
- **`tests/test_rvm.py`** — 13 tests (preprocess/postprocess, stateless predict, stateful sequence predict, statelessness, reset, auto/fixed downsample ratio, callable).
- **Docs** — matting module page + model zoo + license-attribution (**GPL-3.0 weights**), README / quickstart / index / overview mentions.

## Verification

- 13/13 new tests pass; real-model inference validated on **both** variants (MobileNetV3 ~15 MB, ResNet50 ~107 MB) incl. state recycling and geometry-change reset.
- `pre-commit run --files` clean (ruff, ruff-format, bandit).

## Notes for maintainer

- RVM weights are **GPL-3.0** (see updated `docs/license-attribution.md`) — flagged for commercial users.
- Registry points at the official `PeterL1n/RobustVideoMatting` v1.0.0 release. The HF-mirror fallback path won't have these files yet; if you'd like your usual dual-source convention, re-host the two fp32 ONNX files (unchanged bytes, SHAs in the registry) and bump `HF_MIRROR_URL`.